### PR TITLE
Update to Go version 1.21, and go.opentelemetry.io/otel v1.25.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.0
+FROM golang:1.21.0
 
 WORKDIR /usr/src/app
 COPY go.mod .

--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ Once everything is running, periodic requests will be sent to the microservice, 
 curl -X GET http://localhost:8888/hello
 ```
 
+# SELinux Permissions
+
+If your host is running SELinux, the containers may be unable to access files that
+are mounted from volumes, such as `/usr/share/elasticsearch/config/roles.yml`.
+You can fix this by relabeling the files and directories that are to be mounted:
+
+```bash
+    chcon -R -t container_file_t collector-config.yaml environment fleet-server
+```
+
 # License
 
 This project is licensed under the [Apache 2.0 License](./LICENSE).

--- a/collector-config.yaml
+++ b/collector-config.yaml
@@ -15,7 +15,8 @@ extensions:
 exporters:
   otlp:
     endpoint: "http://fleet-server:8200"
-    insecure: true
+    tls:
+      insecure: true
 
 service:
   extensions: [health_check]

--- a/go.mod
+++ b/go.mod
@@ -1,35 +1,32 @@
 module otel-with-golang
 
-go 1.17
+go 1.21
 
 require (
-	github.com/gorilla/mux v1.8.0
-	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.29.0
-	go.opentelemetry.io/otel v1.4.1
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.27.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.4.1
-	go.opentelemetry.io/otel/metric v0.27.0
-	go.opentelemetry.io/otel/sdk v1.4.1
-	go.opentelemetry.io/otel/sdk/metric v0.27.0
-	go.opentelemetry.io/otel/trace v1.4.1
-	google.golang.org/grpc v1.44.0
+	github.com/gorilla/mux v1.8.1
+	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.50.0
+	go.opentelemetry.io/otel v1.25.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.25.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.25.0
+	go.opentelemetry.io/otel/metric v1.25.0
+	go.opentelemetry.io/otel/sdk v1.25.0
+	go.opentelemetry.io/otel/sdk/metric v1.25.0
+	go.opentelemetry.io/otel/trace v1.25.0
+	google.golang.org/grpc v1.63.0
 )
 
 require (
-	github.com/cenkalti/backoff/v4 v4.1.2 // indirect
-	github.com/felixge/httpsnoop v1.0.2 // indirect
-	github.com/go-logr/logr v1.2.2 // indirect
+	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.4.1 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.27.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.4.1 // indirect
-	go.opentelemetry.io/otel/internal/metric v0.27.0 // indirect
-	go.opentelemetry.io/proto/otlp v0.12.0 // indirect
-	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
-	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect
-	golang.org/x/text v0.3.7 // indirect
-	google.golang.org/genproto v0.0.0-20220217155828-d576998c0009 // indirect
-	google.golang.org/protobuf v1.27.1 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.25.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.1.0 // indirect
+	golang.org/x/net v0.24.0 // indirect
+	golang.org/x/sys v0.19.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20240401170217-c3f982113cda // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240401170217-c3f982113cda // indirect
+	google.golang.org/protobuf v1.33.0 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -123,9 +123,8 @@ func hello(writer http.ResponseWriter, request *http.Request) {
 
 func buildResponse(writer http.ResponseWriter) response {
 
+	writer.Header().Add("Content-Type", "application/json")
 	writer.WriteHeader(http.StatusOK)
-	writer.Header().Add("Content-Type",
-		"application/json")
 
 	response := response{"Hello World"}
 	bytes, _ := json.Marshal(response)


### PR DESCRIPTION
Thanks for making this handy demo available!  This PR:

* Updates to Go version 1.21, and go.opentelemetry.io/otel v1.25.0.

* Demonstrates how to include the trace ID in log records,  via a structured logger based on `log/slog`.

* Adds a README.md note regarding SELinux issues and the mounted volumes.
